### PR TITLE
(#33) fix: 本番環境のネットワークエラー修正

### DIFF
--- a/backend/config/initializers/cors.rb
+++ b/backend/config/initializers/cors.rb
@@ -5,12 +5,20 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
     # 許可するオリジンを定義
     # 本番環境: 環境変数 FRONTEND_URL に実際のドメインを設定 (例: https://myapp.com)
     # 開発環境: 環境変数がない場合は localhost:3000 をデフォルトとする
-    allowed_origins = ENV.fetch("FRONTEND_URL", "http://localhost:3000")
-
+    
     # もし複数のドメイン（ステージングと本番など）を許可したい場合は、
     # 環境変数をカンマ区切りにして配列化することを推奨します。
     allowed = ENV.fetch("FRONTEND_URLS", ENV.fetch("FRONTEND_URL", "http://localhost:3000"))
     allowed = allowed.split(",").map(&:strip)
+
+    # 本番環境で環境変数が未設定の場合の安全策として Vercel のデフォルトドメインを追加
+    # (環境変数が正しく設定されていれば、この行は実質的に無効)
+    if Rails.env.production? && !allowed.any? { |origin| origin.include?("omamori-three.vercel.app") }
+      allowed << "https://omamori-three.vercel.app"
+    end
+
+    # デバッグ用: 許可されているオリジンをログ出力
+    Rails.logger.info "[CORS] Allowed origins: #{allowed.inspect}"
 
     origins(*allowed)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
     ports:
       - "3000:3000"
     environment:
-      - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL:-http://localhost:3001}
+      - NEXT_PUBLIC_API_BASE_URL=${NEXT_PUBLIC_API_BASE_URL:-http://localhost:3001}
       - WATCHPACK_POLLING=true
     depends_on:
       - backend

--- a/frontend/src/lib/api/csrf.ts
+++ b/frontend/src/lib/api/csrf.ts
@@ -2,7 +2,7 @@
 // - GET /api/v1/auth/csrf からトークンを取得し、クッキーと返却 JSON からトークンを取得します。
 // - 取得後は返り値の関数 `withCsrf` を使って fetch に自動で `X-CSRF-Token` を付与できます。
 
-export async function fetchCsrf(baseUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001') {
+export async function fetchCsrf(baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:3001') {
   const url = `${baseUrl}/api/v1/auth/csrf`;
   const res = await fetch(url, {
     method: 'GET',


### PR DESCRIPTION
- frontend/csrf.ts: 環境変数名をNEXT_PUBLIC_API_BASE_URLに統一
- backend/cors.rb: 本番用デフォルトOrigin追加とデバッグログ実装
- docker-compose.yml: 環境変数名をNEXT_PUBLIC_API_BASE_URLに統一
- #33 