### PR TITLE
(#63) fix(User): roleのDB/モデル不整合とnameの必須化を解消

### DIFF
--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -24,7 +24,8 @@ class User < ApplicationRecord
   store_accessor :settings, :notification_enabled, :dark_mode
 
   # バリデーション
-  validates :name, presence: true, length: { maximum: 50 }
+  # API 経由で名前が必須だと登録失敗になるため、名前は任意にします。
+  validates :name, allow_blank: true, length: { maximum: 50 }
   validates :role, presence: true, inclusion: { in: roles.keys }
   # フロントエンド側では電話番号は任意扱いのため、空白は許容する
   validates :phone_number, allow_blank: true, format: { with: /\A\d{10,11}\z/, message: "は10〜11桁の数字で入力してください" }
@@ -38,7 +39,8 @@ class User < ApplicationRecord
   private
 
   def set_default_role
-    self.role ||= "admin"
+    # enum を利用しているのでシンボルで割り当てる（または整数を使う）
+    self.role ||= :worker
   end
 
   # 3. email

--- a/backend/spec/models/user_spec.rb
+++ b/backend/spec/models/user_spec.rb
@@ -27,7 +27,9 @@ RSpec.describe User do
   # ============================================
   describe "Validations" do
     # --- name ---
-    it { is_expected.to validate_presence_of(:name) }
+    # name は API 経由で必須でないため、空白を許容する
+    it { is_expected.to allow_value(nil).for(:name) }
+    it { is_expected.to allow_value("").for(:name) }
     it { is_expected.to validate_length_of(:name).is_at_most(50) }
 
     # --- email ---
@@ -94,7 +96,7 @@ RSpec.describe User do
       it "role が未指定でも作成時にデフォルトが入る" do
         u = build(:user, role: nil)
         u.save!
-        expect(u.role).to eq("admin")
+        expect(u.role).to eq("worker")
       end
     end
   end


### PR DESCRIPTION
-  Userのデフォルト role を  ->  に修正し DB と整合
-  nameのバリデーションを必須から任意に変更（API から名前なしで登録できるように）
-  既存 NULL レコードを (worker) に更新して default と NOT NULL を適用
-  user_specを更新して新挙動（name 任意・デフォルト role=worker）を検証