### PR TITLE
API基盤の拡張 - 招待・組織管理API

### DIFF
--- a/frontend/src/lib/api/invitations.ts
+++ b/frontend/src/lib/api/invitations.ts
@@ -11,9 +11,12 @@ import { API_PATHS } from './paths';
  * @returns 未承諾招待の配列
  * @throws {ApiError} API呼び出しが失敗した場合
  */
-export async function fetchInvitations(organizationId: ApiId): Promise<Invitation[]> {
+export async function fetchInvitations(
+  organizationId: ApiId,
+  signal?: AbortSignal,
+): Promise<Invitation[]> {
   const path = API_PATHS.ORGANIZATIONS.INVITATIONS(organizationId);
-  const res = await api.get<Invitation[]>(path);
+  const res = await api.get<Invitation[]>(path, { signal });
 
   if (res.error || res.data === null) {
     throw new ApiError(

--- a/frontend/src/lib/api/organizations.ts
+++ b/frontend/src/lib/api/organizations.ts
@@ -3,15 +3,20 @@ import { api, ApiError } from './client';
 import { API_PATHS } from './paths';
 
 /**
- * 組織一覧を取得
+ * 単一組織を取得
+ * @param organizationId 組織ID
+ * @param signal AbortSignal（キャンセル用）
  * @throws {ApiError} API呼び出しが失敗した場合
  */
-export async function fetchOrganizations(): Promise<Organization[]> {
-  const res = await api.get<Organization[]>(API_PATHS.ORGANIZATIONS.BASE);
+export async function fetchOrganization(
+  organizationId: ApiId,
+  signal?: AbortSignal,
+): Promise<Organization> {
+  const res = await api.get<Organization>(API_PATHS.ORGANIZATIONS.SHOW(organizationId), { signal });
 
   if (res.error || res.data === null) {
     throw new ApiError(
-      res.error || `failed to fetch organizations: status=${res.status}`,
+      res.error || `failed to fetch organization: status=${res.status}`,
       res.status,
       res.errorBody,
     );

--- a/frontend/src/lib/api/paths.ts
+++ b/frontend/src/lib/api/paths.ts
@@ -21,15 +21,15 @@ export const API_PATHS = {
     MEMBERSHIP: (orgId: string | number, membershipId: string | number) =>
       `/api/v1/organizations/${orgId}/memberships/${membershipId}`,
     CREATE_INVITATION: (id: string | number) => `/api/v1/organizations/${id}/invitations`,
-    INVITATIONS: (id: string | number) => `/api/v1/organizations/${id}/invitations`,
-    INVITATION: (orgId: string | number, invitationId: string | number) =>
-      `/api/v1/organizations/${orgId}/invitations/${invitationId}`,
     ALERTS: (id: string | number) => `/api/v1/organizations/${id}/alerts`,
     ALERTS_SUMMARY: (id: string | number) => `/api/v1/organizations/${id}/alerts/summary`,
     ALERT: (organizationId: string | number, alertId: string | number) =>
       `/api/v1/organizations/${organizationId}/alerts/${alertId}`,
     ACTIVE_WORK_SESSIONS_LATEST_LOCATIONS: (id: string | number) =>
       `/api/v1/organizations/${id}/active_work_sessions/latest_locations`,
+    INVITATIONS: (id: string | number) => `/api/v1/organizations/${id}/invitations`,
+    INVITATION: (orgId: string | number, invitationId: string | number) =>
+      `/api/v1/organizations/${orgId}/invitations/${invitationId}`,
   },
   // 招待受諾
   INVITATIONS: {

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -167,6 +167,13 @@ export interface Organization {
   updated_at?: string;
 }
 
+// 組織更新リクエスト
+export interface UpdateOrganizationRequest {
+  organization: {
+    name: string;
+  };
+}
+
 // 組織情報更新リクエスト
 export interface UpdateOrganizationRequest {
   organization: {


### PR DESCRIPTION
  - API_PATHS に INVITATIONS, INVITATION, UPDATE パスを追加
  - UpdateOrganizationRequest 型を定義
  - fetchInvitations/deleteInvitation 関数を実装
  - fetchOrganization/updateOrganization 関数を実装
  - 全関数で ApiError throw、AbortSignal 対応