### PR TITLE
メンバー管理機能をメンバー一覧画面から削除

### DIFF
--- a/frontend/src/app/dashboard/organizations/[id]/members/__tests__/page.test.tsx
+++ b/frontend/src/app/dashboard/organizations/[id]/members/__tests__/page.test.tsx
@@ -9,10 +9,6 @@ jest.mock('@/lib/api/memberships', () => ({
   fetchMemberships: jest.fn(),
 }));
 
-jest.mock('@/components/organization/InviteMemberModal', () => ({
-  InviteMemberModal: () => null,
-}));
-
 describe('MembersPage', () => {
   beforeEach(() => {
     jest.clearAllMocks();


### PR DESCRIPTION


## 概要

メンバー一覧画面（Members Page）から管理機能（ロール変更・削除・招待）を削除し、運用機能（リモート見守り開始/終了、稼働ステータス表示、基本情報導線）に特化させました。


## 変更の目的・背景

### 責任分離の完成
- **Issue #175（前提）**: 設定画面（Settings）に組織情報・メンバー管理機能を実装
- **Issue #176（本PR）**: メンバー画面から管理機能を削除し、運用用途に特化

ダッシュボード内のUI・UXを整理し、各画面の役割を明確にすることで：
- 組織管理者：設定画面で権限管理・メンバー招待を実施
- 運用担当者：メンバー画面でリモート見守り操作・稼働状況確認

## 実装の詳細

### 削除した機能

1. **招待機能の削除**
   - `InviteMemberModal` コンポーネントの削除
   - メンバー一覧ヘッダーの「メンバーを招待」ボタンを削除
   - 関連する state (`isModalOpen`) 及び ハンドラー (`handleInviteSuccess`) をクリーンアップ

2. **ロール変更機能の削除**
   - ロール表示をインタラクティブなセレクト要素から read-only バッジ UI に変更
   - 編集不可能な表示のみ提供し、運用側でも「誰が Admin か」を把握可能に保持

3. **削除ボタンの削除**
   - 削除アクション関連のUI/操作を完全に取り除き

### 保持した機能

- ✅ **リモート見守り開始/終了トグル** (`MemberActionToggle`)  
  運用側の主要な操作として完全に保持
- ✅ **稼働ステータス表示** (`WorkStatusBadge`)  
  「見守り中」/「待機中」の状態表示
- ✅ **基本情報への導線**  
  作業ログリンクの遷移先を基本情報タブに変更（旧：移動履歴タブ直接）