### PR TITLE
E2E: 組織（Organizations）テスト

### DIFF
--- a/frontend/e2e/organizations/org-list.spec.ts
+++ b/frontend/e2e/organizations/org-list.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test';
+
+import { getDashboardUrl, loginAsAdmin, mockOrganizations } from '../helpers';
+import { MOCK_ORG } from '../fixtures/organizations';
+
+test.describe('組織管理', () => {
+  test('組織一覧が表示される（1件以上）', async ({ page }) => {
+    await loginAsAdmin(page);
+    await mockOrganizations(page, [MOCK_ORG]);
+
+    await page.goto(getDashboardUrl());
+
+    // 組織がある場合、オンボーディング（組織作成モーダル）は開かれない
+    await expect(page.getByRole('dialog', { name: '組織を作成' })).toHaveCount(0);
+
+    // サイドバーが組織取得を完了し、メニューが表示される
+    const sidebarNav = page.getByRole('navigation', { name: 'サイドバー ナビゲーション' });
+    await expect(sidebarNav.getByRole('link', { name: 'メンバー' })).toBeVisible();
+  });
+
+  test('組織一覧が0件の場合、作成導線（モーダル）が表示される', async ({ page }) => {
+    await loginAsAdmin(page);
+    await mockOrganizations(page, []);
+
+    await page.goto(getDashboardUrl());
+
+    const dialog = page.getByRole('dialog', { name: '組織を作成' });
+    await expect(dialog).toBeVisible();
+
+    await expect(dialog.getByLabel('組織名')).toBeVisible();
+    await expect(dialog.getByRole('button', { name: '作成する' })).toBeVisible();
+  });
+});

--- a/frontend/e2e/organizations/org-not-found.spec.ts
+++ b/frontend/e2e/organizations/org-not-found.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test';
+
+import { fulfillJson, getMembersUrl, loginAsAdmin, mockOrganizations } from '../helpers';
+import { MOCK_ORG } from '../fixtures/organizations';
+
+const NOT_FOUND_ORG_ID = 999999;
+
+test.describe('組織管理', () => {
+  test('存在しない組織IDにアクセスした場合、エラー表示が出る', async ({ page }) => {
+    await loginAsAdmin(page);
+    await mockOrganizations(page, [MOCK_ORG]);
+
+    await page.route(`**/api/v1/organizations/${NOT_FOUND_ORG_ID}/memberships`, async (route) => {
+      if (route.request().method() !== 'GET') return route.fallback();
+      await fulfillJson(route, 404, { status: 'error', errors: ['Not Found'] });
+    });
+
+    await page.goto(getMembersUrl(NOT_FOUND_ORG_ID));
+
+    // ページがクラッシュせず、ユーザーに分かるエラーが表示される
+    await expect(
+      page.getByText('読み込みに失敗しました。時間をおいて再度お試しください。'),
+    ).toBeVisible();
+  });
+});

--- a/frontend/e2e/organizations/org-select-to-members.spec.ts
+++ b/frontend/e2e/organizations/org-select-to-members.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '@playwright/test';
+
+import { getMembersUrl, loginAsAdmin, mockMemberships, mockOrganizations } from '../helpers';
+import { MOCK_ORG } from '../fixtures/organizations';
+import { MOCK_ORG_ID, MOCK_WORKER_ID } from '../fixtures/users';
+
+const MEMBERSHIP_ID = 1;
+
+test.describe('組織管理', () => {
+  test('組織を選択してメンバー一覧に遷移できる', async ({ page }) => {
+    await loginAsAdmin(page);
+    await mockOrganizations(page, [MOCK_ORG]);
+
+    await mockMemberships(page, MOCK_ORG_ID, () => [
+      {
+        id: MEMBERSHIP_ID,
+        user_id: MOCK_WORKER_ID,
+        email: 'worker@example.com',
+        role: 'worker',
+        active_work_session: { active: false, id: null },
+      },
+    ]);
+
+    await page.goto(getMembersUrl(MOCK_ORG_ID));
+
+    await expect(page).toHaveURL(getMembersUrl(MOCK_ORG_ID));
+    await expect(page.getByRole('heading', { name: 'メンバー一覧' })).toBeVisible();
+
+    // 一覧が描画されていること（最低限）
+    await expect(page.getByText('待機中')).toBeVisible();
+  });
+});


### PR DESCRIPTION

## 概要
- 組織一覧表示、組織選択時のメンバー一覧遷移、存在しない組織へのアクセス時のエラー表示を E2E でテストします。
- 管理者が安全に組織管理画面を操作でき、エラー時も適切に対応できることを確認します。

## 変更の目的・背景
- 複数組織を持つアプリでは、組織一覧表示とスムーズな遷移が UX の基本です。
- オンボーディング（組織0件時の作成モーダル）は新規ユーザーの導線として重要です。
- 存在しない組織へのアクセスは珍しくないため（URL共有時の期限切れ等）、404 等のエラーハンドリングが必須です。
- これらのシナリオを E2E で網羅することで、本番環境での組織管理周りの安定性を向上させます。

## 実装の詳細

### 1. 組織一覧表示テスト（2パターン）

#### 1.1 組織1件以上の場合（`org-list.spec.ts`）
```
Steps:
  1. 管理者ユーザーでログイン済み状態を用意する
  2. 組織一覧にMOCK_ORG（1件）を返す
  3. `/dashboard` を開く

Expected Results:
  - 組織作成モーダルが表示されない（0件時のみ表示される）
  - サイドバーのナビゲーションが表示される（組織取得成功の証）
```

#### 1.2 組織0件の場合（`org-list.spec.ts`）
```
Steps:
  1. 管理者ユーザーでログイン済み状態を用意する
  2. 組織一覧に空配列を返す
  3. `/dashboard` を開く

Expected Results:
  - 「組織を作成」ダイアログが開かれる（オンボーディング）
  - 組織名入力フィールドと「作成する」ボタンが表示される
```

### 2. 組織選択→メンバー遷移テスト（`org-select-to-members.spec.ts`）
```
Steps:
  1. 管理者ユーザーでログイン済み状態を用意する
  2. `/dashboard/organizations/:id/members` へ直接ナビゲート
  3. メンバー一覧APIをモック

Expected Results:
  - URLが正しく `/dashboard/organizations/:id/members` となっている
  - 「メンバー一覧」見出しが表示される
  - メンバー表示（最低限：ステータスが「待機中」等）
```

### 3. 存在しない組織へのアクセステスト（`org-not-found.spec.ts`）
```
Steps:
  1. 管理者ユーザーでログイン済み状態を用意する
  2. 存在しないorgId（999999等）で `/dashboard/organizations/:id/members` を開く
  3. memberships APIを404で返すようモック

Expected Results:
  - ページがクラッシュしない
  - ユーザーに分かるエラーメッセージが表示される
    （「読み込みに失敗しました。時間をおいて再度お試しください。」）
```