### PR TITLE
本番環境のドメイン名を omamoriworker.com に修正

### DIFF
--- a/backend/app/controllers/application_controller.rb
+++ b/backend/app/controllers/application_controller.rb
@@ -54,7 +54,7 @@ class ApplicationController < ActionController::API
 
   def allowed_origins
     [
-      "https://omamori-three.vercel.app",
+      "https://omamoriworker.com",
       "http://localhost:3000",
       "http://localhost:3001"
     ]

--- a/backend/config/initializers/cors.rb
+++ b/backend/config/initializers/cors.rb
@@ -5,7 +5,7 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
     # 許可するオリジンを厳密に定義（スキーム補完禁止）
     allowed = [
       "http://localhost:3000",
-      "https://omamori-three.vercel.app"
+      "https://omamoriworker.com"
     ]
 
     # 末尾スラッシュのみ削除


### PR DESCRIPTION


## 概要
本番環境（Render/Vercel）のデプロイに伴い、ドメイン名を `omamori-three.vercel.app` から `omamoriworker.com` に統一しました。
バックエンド側の CORS 設定と Origin 検証を更新し、新ドメインからのリクエストを正しく処理できるようにしました。

## 変更の目的・背景
- Neon DB への移行に伴い、本番環境のドメイン名を カスタムドメイン（omamoriworker.com）に変更
- Render（バックエンド）と Vercel（フロントエンド）の両環境で統一されたドメイン名を使用
- セキュリティ上、CORS と Origin 検証を新ドメインに対応させる必要があった

## 実装の詳細

### 1. CORS 設定の更新
**ファイル**: `backend/config/initializers/cors.rb`
- 許可するオリジンを更新
  - 旧: `"https://omamori-three.vercel.app"`
  - 新: `"https://omamoriworker.com"`
- localhost 開発環境は変更なし

### 2. Origin 検証の更新
**ファイル**: `backend/app/controllers/application_controller.rb`
- `allowed_origins` メソッドを更新
  - 旧: `"https://omamori-three.vercel.app"`
  - 新: `"https://omamoriworker.com"`
- リクエストの Origin ヘッダー と Referer を検証時に新ドメインをチェック