### PR TITLE
Worker画面で通知バナーがフッターナビの背後に隠れる問題を修正

### DIFF
--- a/frontend/src/components/ui/NotificationBanner.tsx
+++ b/frontend/src/components/ui/NotificationBanner.tsx
@@ -51,7 +51,7 @@ export default function NotificationBanner({
 
   return (
     <div
-      className="fixed top-4 inset-x-4 sm:inset-x-auto sm:left-1/2 sm:-translate-x-1/2 z-60 max-w-md"
+      className="fixed top-4 inset-x-4 sm:inset-x-auto sm:left-1/2 sm:-translate-x-1/2 z-[60] max-w-md"
       role="alert"
       aria-live="polite"
       aria-atomic="true"


### PR DESCRIPTION


## 概要
NotificationBannerコンポーネントの z-index クラスを `z-60`（Tailwindで未定義）から `z-[60]`に変更し、Worker画面でエラー通知がフッターナビゲーションより前面に表示されるようにしました。

## 変更の目的・背景
**Issue**: Worker画面で通知バナーがフッターナビやその他の固定要素の背後に隠れてしまう
- Tailwind CSS のデフォルト z-index スケールに `z-60` が存在しないため、クラスが生成されず `z-index: auto` のままになっていた
- ユーザーがエラーメッセージに気付きにくくなり、UX上の問題を引き起こしていた

**解決方法**: Tailwind JIT対応の任意値クラス構文 `z-[60]` を使用し、常にスタイルが反映されるようにする