### PR TITLE
 新規登録画面の電話番号入力欄を削除

### DIFF
--- a/frontend/src/app/(auth)/register/RegisterForm.tsx
+++ b/frontend/src/app/(auth)/register/RegisterForm.tsx
@@ -146,18 +146,6 @@ export default function RegisterForm({ onRegisterSuccess }: RegisterFormProps) {
 
       <div>
         <Input
-          id="phone"
-          name="phone"
-          type="tel"
-          label="電話番号（任意）"
-          value={phoneNumber}
-          onChange={(e) => setPhoneNumber(e.target.value)}
-          placeholder="090-1234-5678"
-        />
-      </div>
-
-      <div>
-        <Input
           id="password"
           name="password"
           type="password"


### PR DESCRIPTION


## 概要
新規登録画面から電話番号入力欄のUIを削除する。送信パラメータやバリデーション、バックエンドは現状のままで、フロントのUI表示のみを対応する。

## 背景・目的
現状、新規登録時に電話番号は任意項目として扱われており、実装上必須ではない。UIから電話番号入力を削除することで、新規登録フローを簡潔にし、ユーザー体験を向上させる。

## 前提
- フロントエンドは Next.js (App Router) + TypeScript
- 電話番号はバックエンド側で `allow_blank: true` で許容されている
- UI削除のみ行い、送信パラメータやバリデーションロジックは現状維持

## 参照
- [frontend/src/app/(auth)/register/RegisterForm.tsx](frontend/src/app/(auth)/register/RegisterForm.tsx) - 登録フォームコンポーネント

## 完了条件
- 新規登録画面から電話番号入力欄が表示されなくなる
- 登録フローが正常に動作する（送信・認証成功）
- 他の入力欄（メール、パスワード等）の表示に変化がない

## 実装タスク
1. RegisterForm.tsx から電話番号入力フィールド（UIのみ）を削除
   - `phoneNumber` state/バリデーション/API送信は当面維持
   - 空欄のまま送信される動作は許容
2. 登録画面の動作確認